### PR TITLE
Replace passwords/tokens with "dummy" only if they are not empty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@
  */
 
 plugins {
-  id 'org.scm-manager.smp' version '0.10.1'
+  id 'org.scm-manager.smp' version '0.10.3'
 }
 
 dependencies {

--- a/gradle/changelog/empty_passwords.yaml
+++ b/gradle/changelog/empty_passwords.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Replace passwords/tokens with "dummy" only if they are not empty ([#43](https://github.com/scm-manager/scm-jenkins-plugin/pull/43))

--- a/src/main/java/sonia/scm/jenkins/GlobalJenkinsConfigurationMapper.java
+++ b/src/main/java/sonia/scm/jenkins/GlobalJenkinsConfigurationMapper.java
@@ -25,6 +25,7 @@ package sonia.scm.jenkins;
 
 import com.google.common.annotations.VisibleForTesting;
 import de.otto.edison.hal.Links;
+import org.apache.commons.lang.StringUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -46,7 +47,7 @@ public abstract class GlobalJenkinsConfigurationMapper {
   private ScmPathInfoStore scmPathInfoStore;
 
   @VisibleForTesting
-  @SuppressWarnings("squid:S2068")
+  @SuppressWarnings("squid:S2068") // we have no password here
   static final String DUMMY_SECRET = "__DUMMY__";
 
   public abstract GlobalJenkinsConfigurationDto map(GlobalJenkinsConfiguration config);
@@ -55,7 +56,9 @@ public abstract class GlobalJenkinsConfigurationMapper {
 
   @AfterMapping
   public void replaceSecretsWithDummy(@MappingTarget GlobalJenkinsConfigurationDto target) {
-    target.setApiToken(DUMMY_SECRET);
+    if (StringUtils.isNotEmpty(target.getApiToken())) {
+      target.setApiToken(DUMMY_SECRET);
+    }
   }
 
   @AfterMapping

--- a/src/main/java/sonia/scm/jenkins/JenkinsConfigurationMapper.java
+++ b/src/main/java/sonia/scm/jenkins/JenkinsConfigurationMapper.java
@@ -25,6 +25,7 @@ package sonia.scm.jenkins;
 
 import com.google.common.annotations.VisibleForTesting;
 import de.otto.edison.hal.Links;
+import org.apache.commons.lang.StringUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -56,8 +57,12 @@ public abstract class JenkinsConfigurationMapper {
 
   @AfterMapping
   public void replaceSecretsWithDummy(@MappingTarget JenkinsConfigurationDto target) {
-    target.setApiToken(DUMMY_SECRET);
-    target.setToken(DUMMY_SECRET);
+    if (StringUtils.isNotEmpty(target.getApiToken())) {
+      target.setApiToken(DUMMY_SECRET);
+    }
+    if (StringUtils.isNotEmpty(target.getToken())) {
+      target.setToken(DUMMY_SECRET);
+    }
   }
 
   @AfterMapping


### PR DESCRIPTION
## Proposed changes

Password, tokens and secrets should not be replaced with the "dummy" password if they are empty and sent to the client so that the UI shows the existence of a password properly.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
