### PR TITLE
Disable svn hook without jenkins url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@
  */
 
 plugins {
-  id 'org.scm-manager.smp' version '0.10.3'
+  id 'org.scm-manager.smp' version '0.11.1'
 }
 
 dependencies {

--- a/gradle/changelog/svn_hook.yaml
+++ b/gradle/changelog/svn_hook.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Disable svn hook without jenkins url ([#48](https://github.com/scm-manager/scm-jenkins-plugin/pull/48))

--- a/src/main/java/sonia/scm/jenkins/JenkinsSvnGlobalHookHandler.java
+++ b/src/main/java/sonia/scm/jenkins/JenkinsSvnGlobalHookHandler.java
@@ -35,6 +35,7 @@ import sonia.scm.repository.api.LookupCommandBuilder;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.util.HttpUtil;
+import sonia.scm.util.Util;
 
 import java.io.IOException;
 import java.text.MessageFormat;
@@ -62,7 +63,7 @@ public class JenkinsSvnGlobalHookHandler implements JenkinsHookHandler {
 
   @Override
   public void sendRequest(RepositoryHookEvent event) {
-    if (!configuration.isDisableSubversionTrigger()) {
+    if (Util.isNotEmpty(configuration.getUrl()) && !configuration.isDisableSubversionTrigger()) {
       try (RepositoryService repositoryService = repositoryServiceFactory.create(event.getRepository())) {
         Optional<String> uuid = lookupUUID(repositoryService);
         if (uuid.isPresent()) {

--- a/src/test/java/sonia/scm/jenkins/JenkinsSvnGlobalHookHandlerTest.java
+++ b/src/test/java/sonia/scm/jenkins/JenkinsSvnGlobalHookHandlerTest.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
@@ -105,6 +106,17 @@ class JenkinsSvnGlobalHookHandlerTest {
   void shouldNotSendRequestIfTriggerIsDisabled() {
     Repository repository = RepositoryTestData.createHeartOfGold();
     when(config.isDisableSubversionTrigger()).thenReturn(true);
+    when(config.getUrl()).thenReturn("http://jenkins.io/scm/");
+
+    handler.sendRequest(new RepositoryHookEvent(hookContext, repository, RepositoryHookType.POST_RECEIVE));
+
+    verify(advancedHttpClient, never()).post(anyString());
+  }
+
+  @Test
+  void shouldNotSendRequestIfUrlIsNotSet() {
+    Repository repository = RepositoryTestData.createHeartOfGold();
+    when(config.getUrl()).thenReturn("");
 
     handler.sendRequest(new RepositoryHookEvent(hookContext, repository, RepositoryHookType.POST_RECEIVE));
 


### PR DESCRIPTION
## Proposed changes

The svn hook must not be triggered if the jenkins
url is not set. Otherwise an exception is thrown
due to the malformed url.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
